### PR TITLE
Use __slots__ for python

### DIFF
--- a/pyrb.py
+++ b/pyrb.py
@@ -7,6 +7,8 @@ MAX_DEPTH = 5
 SAMPLES = 50
 
 class Vector3:
+  __slots__ = ("x", "y", "z")
+
   def __init__(self, x = 0, y = 0, z = 0):
     self.x = x
     self.y = y


### PR DESCRIPTION
`__slots__` tells the python interpreter "this object will only ever have these attributes, no more added at runtime" - when a class has many small instances, frequently created and destroyed, it is recommended to use slots for better efficiency.

In my quick test (A 160x90px image), it improves performance by 20% :O

(Adding slots to the other classes who don't get created / destroyed quite so often, the improvement was marginal)